### PR TITLE
House points table visual overhaul and point awarding forms updated with warnings

### DIFF
--- a/House Points/CHANGEDB.php
+++ b/House Points/CHANGEDB.php
@@ -75,3 +75,7 @@ $count++;
 $sql[$count][0]="1.5.03" ; // version number
 $sql[$count][1]="" ;
 $count++;
+
+$sql[$count][0]="1.5.04" ; // version number
+$sql[$count][1]="" ;
+$count++;

--- a/House Points/CHANGELOG.txt
+++ b/House Points/CHANGELOG.txt
@@ -1,7 +1,9 @@
 CHANGELOG
 =========
 ## v1.5.04
-Overhauled main point totals table in home page and added a points by event table.
+Overhauled main point totals table in home page and added a points by event table
+Changed award house points and Award student points forms to emphasise identical 'reason' fields
+Added reason autocomplete dropdown for ease-of-use
 
 ## v1.5.03
 Fixed left students appearing in student point lists

--- a/House Points/CHANGELOG.txt
+++ b/House Points/CHANGELOG.txt
@@ -1,5 +1,8 @@
 CHANGELOG
 =========
+## v1.5.04
+Overhauled main point totals table in home page and added a points by event table.
+
 ## v1.5.03
 Fixed left students appearing in student point lists
 

--- a/House Points/award.php
+++ b/House Points/award.php
@@ -59,11 +59,15 @@ if (isActionAccessible($guid, $connection2,"/modules/House Points/award.php")==F
             $row->addLabel('points', __('Points'));
             $row->addTextField('points')->disabled()->placeholder(__('Select a category'));
 
+        $reasons = $pdo->select("SELECT DISTINCT reason FROM hpPointHouse UNION SELECT DISTINCT reason from hpPointStudent ORDER BY reason")->fetchAll(\PDO::FETCH_COLUMN);
         $row = $form->addRow();
             $row->addLabel('reason', __('Reason'));
-            $row->addTextArea('reason')->setRows(2)->required();
-            
-         $row = $form->addRow();
+            $row->addTextField('reason')->maxLength(100)->required()->autocomplete($reasons);
+        
+        $row = $form->addRow();
+            $row->addAlert(__('If the reason for awarding points already exists, ensure the text in the reason field is the same.'), "warning");
+
+        $row = $form->addRow();
             $row->addFooter();
             $row->addSubmit();
 

--- a/House Points/hook_housepoint.php
+++ b/House Points/hook_housepoint.php
@@ -30,8 +30,8 @@ if (isActionAccessible($guid, $connection2, '/modules/House Points/overall.php')
 
     $totalsTable->addColumn('Crest')
         ->format(function ($row) {
-            $class = !empty($row['houseLogo'])? '' : '';
-            return Format::photo($row['houseLogo'], 'sm', $class);
+            $class = '';
+            return Format::photo($row['houseLogo'], 'md', $class);
     });
     $totalsTable->addColumn('House')
         ->setClass('text-lg text-gray-600 leading-snug')

--- a/House Points/hook_housepoint.php
+++ b/House Points/hook_housepoint.php
@@ -3,9 +3,12 @@
 //Module includes
 require_once './modules/House Points/moduleFunctions.php';
 
+use Gibbon\Module\HousePoints\Domain\HousePointHouseGateway;
 use Gibbon\Services\Format;
 use Gibbon\Tables\DataTable;
 use Gibbon\Tables\View\GridView;
+
+
 
 /*
 if (isActionAccessible($guid, $connection2, '/modules/House Points/overall.php') == false) {
@@ -16,11 +19,14 @@ if (isActionAccessible($guid, $connection2, '/modules/House Points/overall.php')
 
 } else {
 */
+    require_once $session->get('absolutePath').'/modules/House Points/src/Domain/HousePointHouseGateway.php';
     global $container;
+
     $yearID = $session->get('gibbonSchoolYearID');
-    
+    $housePointHouseGateway = $container->get(HousePointHouseGateway::class);
     // POINT TOTALS DATATABLE
-    $pointsList = readPointsList($connection2, $yearID);
+    $pointsList = $housePointHouseGateway->selectAllPoints($yearID);
+    
 
     $gridRenderer = new GridView($container->get('twig'));
     $totalsTable = $container->get(DataTable::class)->setRenderer($gridRenderer);
@@ -47,7 +53,7 @@ if (isActionAccessible($guid, $connection2, '/modules/House Points/overall.php')
     $hook = $totalsTable->render($pointsList->toDataSet());
 
     // EVENT POINTS DATATABLE
-    $eventPointsList = readEventsList($connection2, $yearID);
+    $eventPointsList = $housePointHouseGateway->selectEventsList($yearID);
     $eventPointsList = parseEventsList($eventPointsList);
 
     $eventsTable = $container->get(DataTable::class);

--- a/House Points/hook_housepoint.php
+++ b/House Points/hook_housepoint.php
@@ -3,6 +3,10 @@
 //Module includes
 require_once './modules/House Points/moduleFunctions.php';
 
+use Gibbon\Services\Format;
+use Gibbon\Tables\DataTable;
+use Gibbon\Tables\View\GridView;
+
 /*
 if (isActionAccessible($guid, $connection2, '/modules/House Points/overall.php') == false) {
     //Acess denied
@@ -12,30 +16,57 @@ if (isActionAccessible($guid, $connection2, '/modules/House Points/overall.php')
 
 } else {
 */
+    global $container;
     $yearID = $session->get('gibbonSchoolYearID');
+    
+    // POINT TOTALS DATATABLE
     $pointsList = readPointsList($connection2, $yearID);
 
-    $hook = "";
-    $hook .= "<p>&nbsp;</p>";
-    $hook .= "<h3>Overall House Points</h3>";
-    $hook .= "<table style='width:100%;font-size:14pt'>";
-        $hook .= "<tr>";
-            $hook .= "<th style='width:15%'>Crest</th>";
-            $hook .= "<th style='width:35%'>House</th>";
-            $hook .= "<th style='width:30%'>Points</th>";
-        $hook .= "</tr>";
+    $gridRenderer = new GridView($container->get('twig'));
+    $totalsTable = $container->get(DataTable::class)->setRenderer($gridRenderer);
+    $totalsTable->setTitle(__('Overall House Points'));
+    $totalsTable->addMetaData('hidePagination', true);
+    $totalsTable->addMetaData('gridItemClass', 'w-1/2 sm:w-1/4 md:w-1/3 my-2 text-center');
 
-        while ($row = $pointsList->fetch()) {
-            $hook .= "<tr>";
-                $hook .= "<td class='textCenter'>";
-                if (!empty($row['houseLogo'])) {
-                    $hook .= sprintf('<img src="%1$s" title="%2$s" style="width:auto;height:80px;">', $session->get('absoluteURL').'/'.$row['houseLogo'], $row['houseName'] );
-                }
-                $hook .= "</td>";
-                $hook .= "<td>".$row['houseName']."</td>";
-                $hook .= "<td>".$row['total']."</td>";
-            $hook .= "</tr>";
-        }
-    $hook .= "</table>";
+    $totalsTable->addColumn('Crest')
+        ->format(function ($row) {
+            $class = !empty($row['houseLogo'])? '' : '';
+            return Format::photo($row['houseLogo'], 'sm', $class);
+    });
+    $totalsTable->addColumn('House')
+        ->setClass('text-lg text-gray-600 leading-snug')
+        ->format(function ($row) {
+            return !empty($row['houseName']) ? $row['houseName'] : ('House Name NA');
+    });
+    $totalsTable->addColumn('Total')
+        ->setClass('text-base text-gray-600 leading-snug')
+        ->format(function ($row) {
+            return !empty($row['total']) ? $row['total'] : ('Point Total NA');
+    });
+
+    $hook = $totalsTable->render($pointsList->toDataSet());
+
+    // EVENT POINTS DATATABLE
+    $eventPointsList = readEventsList($connection2, $yearID);
+    $eventPointsList = parseEventsList($eventPointsList);
+
+    $eventsTable = $container->get(DataTable::class);
+    $eventsTable->setTitle(__('House Points By Event'));
+    $eventsTable->addMetaData('hidePagination', true);
+    $eventsTable->addMetaData('gridItemClass', 'w-1/2 sm:w-1/4 md:w-1/5 my-2 text-center');
+    
+    $eventsTable->addColumn('reason', 'Event');
+    foreach($eventPointsList['houses'] as $house) {
+        $eventsTable->addColumn($house, $house);
+    }
+
+    // Re-format NULL cell values to '0'
+    foreach($eventPointsList['houses'] as $house) {
+        $eventsTable->getColumn($house)->format(function ($values) use ($house) { 
+            return !empty($values[$house]) ? $values[$house] : '0';
+        });
+    }
+
+    $hook .= $eventsTable->render($eventPointsList['events']);
     return $hook;
 //}

--- a/House Points/house.php
+++ b/House Points/house.php
@@ -27,7 +27,6 @@ if (isActionAccessible($guid, $connection2,"/modules/House Points/house.php")==F
     //Acess denied
     $page->addError(__('You do not have access to this action.'));
 } else {
-
         $form = Form::create('awardForm', $session->get('absoluteURL') . '/modules/' . $session->get('module') . '/housePointsProcess.php', 'post');
         $form->setTitle('Award house points to house');
         $form->addHiddenValue('address', $session->get('address'));
@@ -59,11 +58,15 @@ if (isActionAccessible($guid, $connection2,"/modules/House Points/house.php")==F
             $row->addLabel('points', __('Points'));
             $row->addTextField('points')->disabled()->placeholder(__('Select a category'));
 
+        $reasons = $pdo->select("SELECT DISTINCT reason FROM hpPointHouse UNION SELECT DISTINCT reason from hpPointStudent ORDER BY reason")->fetchAll(\PDO::FETCH_COLUMN);
         $row = $form->addRow();
             $row->addLabel('reason', __('Reason'));
-            $row->addTextArea('reason')->setRows(2)->required();
-            
-         $row = $form->addRow();
+            $row->addTextField('reason')->maxLength(100)->required()->autocomplete($reasons);
+        
+        $row = $form->addRow();
+            $row->addAlert(__('If the reason for awarding points already exists, ensure the text in the reason field is the same.'), "warning");
+
+        $row = $form->addRow();
             $row->addFooter();
             $row->addSubmit();
 

--- a/House Points/manifest.php
+++ b/House Points/manifest.php
@@ -23,7 +23,7 @@ $description="Module to allow allocating and display of house points (modified b
 $entryURL="overall.php" ;
 $type="Additional" ;
 $category="Learn" ;
-$version="1.5.03" ;
+$version="1.5.04" ;
 $author="Andy Statham" ;
 $url="http://rapid36.com" ;
 

--- a/House Points/moduleFunctions.php
+++ b/House Points/moduleFunctions.php
@@ -17,6 +17,11 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+/**
+ * @DEPRECATED - V1.5.04
+ * Not used anywhere.
+ * 
+ */
 function readMyPoints($dbh, $studentID, $yearID) {
     $data = array(
         'studentID' => $studentID,
@@ -35,81 +40,6 @@ function readMyPoints($dbh, $studentID, $yearID) {
         WHERE hpPointStudent.studentID = :studentID
         AND hpPointStudent.yearID = :yearID
         ORDER BY hpPointStudent.awardedDate DESC";
-    $rs = $dbh->prepare($sql);
-    $rs->execute($data);
-    return $rs;
-}
-
-function readPointsList($dbh, $yearID) {
-    $data = array(
-        'yearID' => $yearID
-    );
-    $sql = "SELECT gibbonHouse.gibbonHouseID AS houseID,
-        gibbonHouse.name AS houseName,
-        gibbonHouse.logo as houseLogo,
-        COALESCE(pointStudent.total + pointHouse.total, pointStudent.total, pointHouse.total, 0) AS total
-        FROM gibbonHouse
-        LEFT JOIN
-        (
-            SELECT gibbonPerson.gibbonHouseID AS houseID,
-            SUM(hpPointStudent.points) AS total
-            FROM hpPointStudent
-            INNER JOIN gibbonPerson
-            ON hpPointStudent.studentID = gibbonPerson.gibbonPersonID
-            WHERE hpPointStudent.yearID=:yearID
-            GROUP BY gibbonPerson.gibbonHouseID
-
-        ) AS pointStudent
-        ON pointStudent.houseID = gibbonHouse.gibbonHouseID
-        LEFT JOIN
-        (
-            SELECT hpPointHouse.houseID,
-            SUM(hpPointHouse.points) AS total
-            FROM hpPointHouse
-            WHERE hpPointHouse.yearID=:yearID
-            GROUP BY hpPointHouse.houseID
-        ) AS pointHouse
-        ON pointHouse.houseID = gibbonHouse.gibbonHouseID
-
-        ORDER BY total DESC";
-    $rs = $dbh->prepare($sql);
-    $rs->execute($data);
-    return $rs;
-}
-
-// Queries for list of points awarded for students and houses.
-function readEventsList($dbh, $yearID) {
-    $data = array(
-        'yearID' => $yearID
-    );
-    $sql = "SELECT gibbonHouse.gibbonHouseID AS houseID,
-    gibbonHouse.name AS houseName,
-    gibbonHouse.logo AS houseLogo,
-    pointOverall.individualPoints AS individualPoints,
-	pointOverall.reason AS reason,
-    pointOverall.awardedDate AS awardedDate
-    FROM gibbonHouse
-    LEFT JOIN
-    (
-        SELECT gibbonPerson.gibbonHouseID AS houseID,
-        hpPointStudent.points AS individualPoints,
-        hpPointStudent.reason AS reason,
-        hpPointStudent.awardedDate AS awardedDate
-        FROM hpPointStudent
-        INNER JOIN gibbonPerson
-        ON hpPointStudent.studentID = gibbonPerson.gibbonPersonID
-        WHERE hpPointStudent.yearID=:yearID
-        UNION
-        SELECT hpPointHouse.houseID,
-        hpPointHouse.points AS individualPoints,
-        hpPointHouse.reason AS reason,
-        hpPointHouse.awardedDate AS awardedDate
-        FROM hpPointHouse
-        WHERE hpPointHouse.yearID=:yearID
-
-    ) AS pointOverall
-    ON pointOverall.houseID = gibbonHouse.gibbonHouseID
-    ORDER BY awardedDate";
     $rs = $dbh->prepare($sql);
     $rs->execute($data);
     return $rs;

--- a/House Points/src/Domain/HousePointHouseGateway.php
+++ b/House Points/src/Domain/HousePointHouseGateway.php
@@ -47,7 +47,7 @@ class HousePointHouseGateway extends QueryableGateway
                 'pointHouse.houseID = gibbonHouse.gibbonHouseID'
             )
             ->bindValue('yearID', $yearID)
-            ->orderBy(['total']);
+            ->orderBy(['total DESC']);
 
         return $this->runSelect($select);
     }
@@ -66,6 +66,42 @@ class HousePointHouseGateway extends QueryableGateway
             ->orderBy(['hpPointHouse.awardedDate']);
 
         return $this->runSelect($select);
+    }
+
+    function selectEventsList($yearID) {
+        $data = array(
+            'yearID' => $yearID
+        );
+        $sql = "SELECT gibbonHouse.gibbonHouseID AS houseID,
+        gibbonHouse.name AS houseName,
+        gibbonHouse.logo AS houseLogo,
+        pointOverall.individualPoints AS individualPoints,
+        pointOverall.reason AS reason,
+        pointOverall.awardedDate AS awardedDate
+        FROM gibbonHouse
+        LEFT JOIN
+        (
+            SELECT gibbonPerson.gibbonHouseID AS houseID,
+            hpPointStudent.points AS individualPoints,
+            hpPointStudent.reason AS reason,
+            hpPointStudent.awardedDate AS awardedDate
+            FROM hpPointStudent
+            INNER JOIN gibbonPerson
+            ON hpPointStudent.studentID = gibbonPerson.gibbonPersonID
+            WHERE hpPointStudent.yearID=:yearID
+            UNION
+            SELECT hpPointHouse.houseID,
+            hpPointHouse.points AS individualPoints,
+            hpPointHouse.reason AS reason,
+            hpPointHouse.awardedDate AS awardedDate
+            FROM hpPointHouse
+            WHERE hpPointHouse.yearID=:yearID
+    
+        ) AS pointOverall
+        ON pointOverall.houseID = gibbonHouse.gibbonHouseID
+        ORDER BY awardedDate";
+        
+        return $this->db()->select($sql, $data);
     }
     
 }

--- a/House Points/version.php
+++ b/House Points/version.php
@@ -20,5 +20,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information
  */
-$moduleVersion = "1.5.03" ;
+$moduleVersion = "1.5.04" ;
 $coreVersion =  "22.0.0";


### PR DESCRIPTION
**Description**
Applied changes to the housePoints hook in the gibbon home page:
- Rearranged logos and point totals to be in a GridView
- Added a DataTable including the points gained per house from recent events

Applied changes to the Award House Points and Award Student Points forms:
- Added alert to the reason field to iterate the importance of identical text for the reason field
- Added an autocomplete dropdown for the 'reason' field for ease-of-use/completion

**Motivation and Context**
The student representative council from a school using Gibbon contacted us with a change for the house points table in mind. Which was then implemented, requiring further changes in different areas for functionality.

**How Has This Been Tested?**
Tested locally.

**Screenshots**
![Screenshot 2024-01-23 at 16 14 57](https://github.com/GibbonEdu/module-housePoints/assets/74660787/fc3dbe09-cd60-4d54-b59d-1d8317c63c55)
![Screenshot 2024-01-23 at 16 18 51](https://github.com/GibbonEdu/module-housePoints/assets/74660787/5aa27b50-646b-4989-92ab-4e879a1ed054)
![Screenshot 2024-01-23 at 16 18 59](https://github.com/GibbonEdu/module-housePoints/assets/74660787/ad37a815-4f4b-4e0d-ae92-3ede65550348)
